### PR TITLE
Bump docformatter from v1.5.0 to v1.7.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/myint/docformatter
-    rev: v1.5.0
+    rev: v1.7.5
     hooks:
     - id: docformatter
       args: [--in-place]


### PR DESCRIPTION
Bumps `pre-commit` hook for `docformatter` from v1.5.0 to v1.7.5 and ran the update against the repo.