### PR TITLE
Correct sphinx-autobuild dependency for Py3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,9 @@ docs = [
     # Sphinx 7.2 deprecated support for Python 3.8
     "sphinx == 7.1.2 ; python_version < '3.9'",
     "sphinx == 7.2.6 ; python_version >= '3.9'",
-    "sphinx-autobuild == 2024.2.4",
+    # Sphinx 2024.2.4 deprecated support for Python 3.8
+    "sphinx-autobuild == 2021.3.14 ; python_version < '3.9'",
+    "sphinx-autobuild == 2024.2.4 ; python_version >= '3.9'",
     "sphinx_rtd_theme == 2.0.0"
 ]
 


### PR DESCRIPTION
Sphinx-autobuild 2024.2.4 deprecated support for Python 3.8. 

This PR adds in a version-conditional pin to allow docs to build on Python 3.8.