### PR TITLE
Update Python version used on RTD builds.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,11 @@ dev = [
 ]
 docs = [
     # Sphinx 7.2 deprecated support for Python 3.8
+    # Sphinx 8.0 deprecated support for Python 3.9
     "sphinx == 7.1.2 ; python_version < '3.9'",
-    "sphinx == 7.4.7 ; python_version >= '3.9'",
-    # Sphinx 2024.2.4 deprecated support for Python 3.8
+    "sphinx == 7.4.7 ; python_version == '3.9'",
+    "sphinx == 7.4.7 ; python_version >= '3.10'",
+    # sphinx-autobuild 2024.2.4 deprecated support for Python 3.8
     "sphinx-autobuild == 2021.3.14 ; python_version < '3.9'",
     "sphinx-autobuild == 2024.4.16 ; python_version >= '3.9'",
     "sphinx_rtd_theme == 2.0.0"


### PR DESCRIPTION
Sphinx 8 deprecates Python 3.9; but we currently use Python 3.9 as part of the RTD configuration. This prevents us from testing any Sphinx 8 updates.

This also adds a protective pin on Sphinx installs, so that dependbot can't update Sphinx on Python 3.9