### PR TITLE
Bump mac_alias from 2.0.1 to 2.2.2  for apple chip.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "mac_alias >= 2.0.1",
+    "mac_alias >= 2.2.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
I ran into this exception, so I forced the mac_alias to update and it was fine.


```
AttributeError: dlsym(0x100ed1690, statfs$INODE64): symbol not found
```


https://github.com/dmgbuild/mac_alias/issues/10

