### PR TITLE
Correct experimental workflows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,27 +49,23 @@ jobs:
   unit-tests:
     name: Unit tests
     needs: pretest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
         macOS-version: [
             # x86_64 runners
             "macos-13",
             # M1 runners
-            "macos-14"
+            "macos-latest"
         ]
 
         include:
           - experimental: false
 
-          - python-version: "3.13"
+          - python-version: "3.14"
             experimental: true
-
-        exclude:
-          # actions/setup-python doesn't provide Python 3.9 for M1.
-          - macOS-version: "macos-14"
-            python-version: "3.9"
 
     runs-on: ${{ matrix.macOS-version }}
     steps:


### PR DESCRIPTION
* Switch to `macOS-latest`
* Include 3.14 as an experimental version
* Remove stale 3.9 runner skip.