### PR TITLE
Bug: Duplicate entries and IndexError during B-tree node splitFix/split duplicate entries

### DIFF
--- a/src/ds_store/store.py
+++ b/src/ds_store/store.py
@@ -555,14 +555,16 @@ class DSStore:
             entries = []
             before = []
             total = 0
+            inserted = False
             for n in range(count):
                 pos = block.tell()
                 if next_node:
                     ptr = block.read(b">I")[0]
                     pointers.append(ptr)
                 e = DSStoreEntry.read(block)
-                if e > entry:
+                if not inserted and e > entry:
                     # ?? entry_pos = n
+                    inserted = True
                     entries.append(entry)
                     pointers.append(right_ptr)
                     before.append(total)
@@ -570,6 +572,13 @@ class DSStore:
                 entries.append(e)
                 before.append(total)
                 total += block.tell() - pos
+            # If entry wasn't inserted (it's larger than all existing), add at end
+            if not inserted:
+                entries.append(entry)
+                if next_node:
+                    pointers.append(right_ptr)
+                before.append(total)
+                total += entry_size
             before.append(total)
             if next_node:
                 pointers.append(next_node)

--- a/src/ds_store/store.py
+++ b/src/ds_store/store.py
@@ -576,12 +576,18 @@ class DSStore:
             if not inserted:
                 entries.append(entry)
                 if next_node:
-                    pointers.append(right_ptr)
+                    # For largest entry: next_node becomes the pointer BEFORE entry
+                    pointers.append(next_node)
                 before.append(total)
                 total += entry_size
             before.append(total)
             if next_node:
-                pointers.append(next_node)
+                if inserted:
+                    # Mid-value case: next_node stays as the rightmost pointer
+                    pointers.append(next_node)
+                else:
+                    # Largest entry case: right_ptr becomes the new rightmost pointer
+                    pointers.append(right_ptr)
 
             pivot = self._split2(
                 [block, right_block], entries, pointers, before, bool(next_node)

--- a/tests/test_internal_node_splits.py
+++ b/tests/test_internal_node_splits.py
@@ -1,0 +1,407 @@
+"""Targeted tests for internal node split behavior.
+
+These tests specifically exercise the pointer ordering in internal B-tree nodes
+during split operations. The key scenarios are:
+
+1. Largest pivot insertion - when a leaf split produces a pivot that is larger
+   than all existing entries in the parent internal node
+2. Middle pivot insertion - when a pivot fits between existing entries
+3. Deep tree operations - when splits cascade through multiple levels
+
+The pointer ordering bug manifests when:
+- Inserting the largest entry into an internal node during split
+- The fix must ensure: next_node becomes pointer BEFORE entry,
+  right_ptr becomes the new rightmost pointer
+
+NOTE: We avoid using initial_entries parameter as it has a separate bug.
+Instead, trees are built using regular inserts.
+"""
+
+from ds_store import DSStore, DSStoreEntry
+
+
+class TestInternalNodePointerOrdering:
+    """Tests that verify correct pointer ordering after internal node splits."""
+
+    def make_entry(self, prefix, num, padding_len=100):
+        """Create an entry with controlled size.
+
+        Larger padding = fewer entries per node = easier to trigger splits.
+        With padding_len=100, each entry is ~218 bytes, fitting ~18 per node.
+        """
+        padding = "x" * padding_len
+        name = f"{prefix}{num:04d}{padding}"[: padding_len + 5]
+        return DSStoreEntry(name, b"cmmt", "ustr", "v")
+
+    def test_ascending_insertion_deep_tree(self, tmp_path):
+        """Insert entries in strict ascending order to build a deep tree.
+
+        This exercises the 'largest entry' code path at every level:
+        - Each leaf insertion is larger than existing leaf entries
+        - Each pivot promoted to internal nodes is larger than existing pivots
+        - When internal nodes split, the pivot is again the largest
+
+        If pointer ordering is wrong, tree traversal will fail to find entries.
+        """
+        ds_path = tmp_path / ".DS_Store"
+
+        # Build tree with ascending insertions (always 'largest')
+        all_filenames = []
+        with DSStore.open(str(ds_path), "w+") as ds:
+            # Insert enough entries to create a multi-level tree
+            for i in range(500):
+                entry = self.make_entry("f", i)
+                all_filenames.append(entry.filename)
+                ds.insert(entry)
+            assert ds._levels >= 2, f"Need multi-level tree, got {ds._levels} levels"
+
+        # Verify EVERY entry can be found
+        with DSStore.open(str(ds_path), "r") as ds:
+            for filename in all_filenames:
+                found = list(ds.find(filename))
+                assert len(found) == 1, (
+                    f"Expected 1 copy of {filename[:30]}..., found {len(found)}"
+                )
+
+    def test_descending_then_ascending(self, tmp_path):
+        """Insert in descending order, then ascending order.
+
+        Descending: each entry is smallest, inserted at beginning
+        Ascending: each entry is largest, inserted at end
+
+        This creates a tree with entries at both extremes.
+        """
+        ds_path = tmp_path / ".DS_Store"
+
+        all_filenames = []
+
+        with DSStore.open(str(ds_path), "w+") as ds:
+            # Insert 'a' entries in descending order (each is new smallest)
+            for i in range(100, -1, -1):
+                entry = self.make_entry("a", i)
+                all_filenames.append(entry.filename)
+                ds.insert(entry)
+
+            # Insert 'z' entries in ascending order (each is new largest)
+            for i in range(101):
+                entry = self.make_entry("z", i)
+                all_filenames.append(entry.filename)
+                ds.insert(entry)
+
+        # Verify all entries
+        with DSStore.open(str(ds_path), "r") as ds:
+            for filename in all_filenames:
+                found = list(ds.find(filename))
+                assert len(found) == 1, (
+                    f"Expected 1 copy of {filename[:30]}..., found {len(found)}"
+                )
+
+            # Also verify total count
+            all_entries = list(ds)
+            assert len(all_entries) == len(all_filenames)
+
+    def test_interleaved_largest_and_middle(self, tmp_path):
+        """Alternate between inserting largest and middle entries.
+
+        This exercises both code paths in the same tree and verifies
+        they don't interfere with each other.
+        """
+        ds_path = tmp_path / ".DS_Store"
+
+        inserted = []
+
+        with DSStore.open(str(ds_path), "w+") as ds:
+            # Start with some 'm' entries
+            for i in range(50):
+                entry = self.make_entry("m", i * 10)  # m0000, m0010, m0020, ...
+                ds.insert(entry)
+                inserted.append(entry.filename)
+
+            # Interleave insertions
+            for i in range(50):
+                # Insert a 'z' entry (largest)
+                z_entry = self.make_entry("z", i)
+                ds.insert(z_entry)
+                inserted.append(z_entry.filename)
+
+                # Insert an 'a' entry (smallest)
+                a_entry = self.make_entry("a", i)
+                ds.insert(a_entry)
+                inserted.append(a_entry.filename)
+
+                # Insert a middle entry (between existing 'm' entries)
+                mid_entry = self.make_entry("m", i * 10 + 5)  # m0005, m0015, etc.
+                ds.insert(mid_entry)
+                inserted.append(mid_entry.filename)
+
+        # Verify all entries exist exactly once
+        with DSStore.open(str(ds_path), "r") as ds:
+            all_entries = list(ds)
+            assert len(all_entries) == len(inserted), (
+                f"Expected {len(inserted)} entries, got {len(all_entries)}"
+            )
+
+            # Check for duplicates
+            filenames = [e.filename for e in all_entries]
+            assert len(filenames) == len(set(filenames)), "Duplicates detected"
+
+
+class TestTreeTraversalIntegrity:
+    """Tests that verify tree traversal works correctly after splits."""
+
+    def make_entry(self, prefix, num, padding_len=100):
+        padding = "x" * padding_len
+        name = f"{prefix}{num:04d}{padding}"[: padding_len + 5]
+        return DSStoreEntry(name, b"cmmt", "ustr", "v")
+
+    def test_find_in_different_subtrees(self, tmp_path):
+        """Verify find() works for entries in different subtrees.
+
+        If internal node pointers are wrong, entries in certain subtrees
+        will be unreachable via find().
+        """
+        ds_path = tmp_path / ".DS_Store"
+
+        # Create entries across the alphabet to ensure they end up in different subtrees
+        prefixes = ["a", "f", "k", "p", "u", "z"]
+        all_entries = {}
+
+        with DSStore.open(str(ds_path), "w+") as ds:
+            for prefix in prefixes:
+                all_entries[prefix] = []
+                for i in range(30):
+                    entry = self.make_entry(prefix, i)
+                    all_entries[prefix].append(entry)
+                    ds.insert(entry)
+
+        # Verify each entry can be found
+        with DSStore.open(str(ds_path), "r") as ds:
+            for prefix in prefixes:
+                for entry in all_entries[prefix]:
+                    found = list(ds.find(entry.filename))
+                    assert len(found) == 1, (
+                        f"{entry.filename[:30]}...: expected 1, got {len(found)}"
+                    )
+
+    def test_iteration_matches_find(self, tmp_path):
+        """Verify that iteration and find() return consistent results.
+
+        If tree structure is corrupted, iteration might return entries
+        that find() cannot locate, or vice versa.
+        """
+        ds_path = tmp_path / ".DS_Store"
+
+        # Create a moderately sized tree
+        with DSStore.open(str(ds_path), "w+") as ds:
+            for i in range(500):
+                ds.insert(self.make_entry("f", i))
+
+        with DSStore.open(str(ds_path), "r") as ds:
+            # Get all entries via iteration
+            all_entries = list(ds)
+
+            # Verify each can be found
+            for entry in all_entries:
+                found = list(ds.find(entry.filename))
+                assert len(found) >= 1, (
+                    f"Entry {entry.filename[:30]}... found in iteration but not find()"
+                )
+                assert len(found) == 1, (
+                    f"Entry {entry.filename[:30]}... has {len(found)} copies"
+                )
+
+
+class TestInternalNodeSplitScenarios:
+    """Specific scenarios designed to trigger internal node splits."""
+
+    def make_entry(self, prefix, num, padding_len=100):
+        padding = "x" * padding_len
+        name = f"{prefix}{num:04d}{padding}"[: padding_len + 5]
+        return DSStoreEntry(name, b"cmmt", "ustr", "v")
+
+    def test_force_internal_split_with_largest(self, tmp_path):
+        """Force internal node splits where the pivot is the largest entry.
+
+        Strategy:
+        1. Build a multi-level tree with regular inserts
+        2. Continue inserting in ascending order
+        3. Each insertion triggers the 'largest entry' code path
+        4. Eventually internal nodes fill and split
+        """
+        ds_path = tmp_path / ".DS_Store"
+
+        # Build tree with ascending insertions
+        all_filenames = []
+        with DSStore.open(str(ds_path), "w+") as ds:
+            # Insert enough to create internal nodes
+            for i in range(400):
+                entry = self.make_entry("f", i)
+                all_filenames.append(entry.filename)
+                ds.insert(entry)
+
+            assert ds._levels >= 2, f"Expected >= 2 levels, got {ds._levels}"
+
+        # Verify tree integrity
+        with DSStore.open(str(ds_path), "r") as ds:
+            all_entries = list(ds)
+            assert len(all_entries) == len(all_filenames), (
+                f"Expected {len(all_filenames)} entries, got {len(all_entries)}"
+            )
+
+            # Verify no duplicates
+            filenames = [e.filename for e in all_entries]
+            assert len(filenames) == len(set(filenames)), "Duplicates detected"
+
+    def test_deep_tree_splits(self, tmp_path):
+        """Test splits in a deep tree (2+ levels).
+
+        With multiple levels, splits can cascade from leaves through
+        internal nodes. This verifies the fix works at all levels.
+        """
+        ds_path = tmp_path / ".DS_Store"
+
+        # Build a multi-level tree with ascending insertions
+        all_filenames = []
+        with DSStore.open(str(ds_path), "w+") as ds:
+            # Insert enough for multiple levels
+            for i in range(600):
+                entry = self.make_entry("f", i)
+                all_filenames.append(entry.filename)
+                ds.insert(entry)
+
+            assert ds._levels >= 2, f"Expected >= 2 levels, got {ds._levels}"
+
+        # Verify all entries are findable
+        with DSStore.open(str(ds_path), "r") as ds:
+            for filename in all_filenames:
+                found = list(ds.find(filename))
+                assert len(found) == 1, (
+                    f"Expected 1 copy of {filename[:30]}..., found {len(found)}"
+                )
+
+    def test_alternating_prefixes_ascending(self, tmp_path):
+        """Insert entries with alternating prefixes in ascending order.
+
+        This creates a more complex tree structure where entries are
+        distributed across subtrees but each insertion is still 'largest'
+        within its local context.
+        """
+        ds_path = tmp_path / ".DS_Store"
+
+        prefixes = ["a", "m", "z"]
+        all_filenames = []
+
+        with DSStore.open(str(ds_path), "w+") as ds:
+            for i in range(150):
+                for prefix in prefixes:
+                    entry = self.make_entry(prefix, i)
+                    all_filenames.append(entry.filename)
+                    ds.insert(entry)
+
+        with DSStore.open(str(ds_path), "r") as ds:
+            # Verify count
+            all_entries = list(ds)
+            assert len(all_entries) == len(all_filenames)
+
+            # Verify all findable
+            for filename in all_filenames:
+                found = list(ds.find(filename))
+                assert len(found) == 1
+
+
+class TestEdgeCases:
+    """Edge cases for split behavior."""
+
+    def make_entry(self, prefix, num, padding_len=100):
+        padding = "x" * padding_len
+        name = f"{prefix}{num:04d}{padding}"[: padding_len + 5]
+        return DSStoreEntry(name, b"cmmt", "ustr", "v")
+
+    def test_single_entry_difference(self, tmp_path):
+        """Test when new entry differs from existing by minimal amount.
+
+        Insert entries like: m0000, m0010, m0020, then m0005, m0015, etc.
+        This tests precise ordering at split boundaries.
+        """
+        ds_path = tmp_path / ".DS_Store"
+
+        inserted = []
+
+        with DSStore.open(str(ds_path), "w+") as ds:
+            # Create base entries
+            for i in range(50):
+                entry = self.make_entry("m", i * 10)
+                ds.insert(entry)
+                inserted.append(entry.filename)
+
+            # Insert entries between existing ones
+            for i in range(50):
+                entry = self.make_entry("m", i * 10 + 5)
+                ds.insert(entry)
+                inserted.append(entry.filename)
+
+        # Verify all entries
+        with DSStore.open(str(ds_path), "r") as ds:
+            all_entries = list(ds)
+            assert len(all_entries) == 100
+
+            # Verify order
+            filenames = [e.filename for e in all_entries]
+            assert filenames == sorted(filenames), "Entries not in sorted order"
+
+    def test_many_sequential_largest_insertions(self, tmp_path):
+        """Insert 1000 entries in strict ascending order.
+
+        Every single insertion is the 'largest' entry.
+        This is the worst case for the pointer ordering bug.
+        """
+        ds_path = tmp_path / ".DS_Store"
+
+        filenames = []
+        with DSStore.open(str(ds_path), "w+") as ds:
+            for i in range(1000):
+                entry = self.make_entry("f", i)
+                filenames.append(entry.filename)
+                ds.insert(entry)
+
+        # Verify all entries
+        with DSStore.open(str(ds_path), "r") as ds:
+            all_entries = list(ds)
+            assert len(all_entries) == 1000, f"Expected 1000, got {len(all_entries)}"
+
+            # Verify each is findable
+            for filename in filenames:
+                found = list(ds.find(filename))
+                assert len(found) == 1, (
+                    f"{filename[:30]}...: expected 1, got {len(found)}"
+                )
+
+    def test_reverse_then_forward(self, tmp_path):
+        """Insert in reverse order, then continue forward.
+
+        This tests the transition from 'smallest' insertions to 'largest'.
+        """
+        ds_path = tmp_path / ".DS_Store"
+
+        filenames = []
+
+        with DSStore.open(str(ds_path), "w+") as ds:
+            # Reverse order: 199, 198, ..., 0
+            for i in range(199, -1, -1):
+                entry = self.make_entry("f", i)
+                filenames.append(entry.filename)
+                ds.insert(entry)
+
+            # Forward order: 200, 201, ..., 399
+            for i in range(200, 400):
+                entry = self.make_entry("f", i)
+                filenames.append(entry.filename)
+                ds.insert(entry)
+
+        with DSStore.open(str(ds_path), "r") as ds:
+            all_entries = list(ds)
+            assert len(all_entries) == 400
+
+            for filename in filenames:
+                found = list(ds.find(filename))
+                assert len(found) == 1

--- a/tests/test_split_bug.py
+++ b/tests/test_split_bug.py
@@ -9,16 +9,15 @@ These tests FAIL with the current implementation and will PASS once fixed.
 
 from ds_store import DSStore, DSStoreEntry
 
-
 # Constants from the DS_Store implementation
 PAGE_SIZE = 4096
 HEADER_SIZE = 8  # next_node (4 bytes) + count (4 bytes)
 AVAILABLE = PAGE_SIZE - HEADER_SIZE  # 4088 bytes
 
 
-def entry_size(filename, value='x'):
+def entry_size(filename, value="x"):
     """Calculate the byte size of an entry."""
-    entry = DSStoreEntry(filename, b'cmmt', 'ustr', value)
+    entry = DSStoreEntry(filename, b"cmmt", "ustr", value)
     return entry.byte_length()
 
 
@@ -38,13 +37,10 @@ class TestSplitWithLargestEntry:
         # Each entry 'fNNN'/'c' is 26 bytes
         # 157 entries = 4082 bytes, leaving 6 bytes remaining
         # Any new entry (min 24 bytes) will trigger a split
-        entries = [
-            DSStoreEntry(f'f{i:03d}', b'cmmt', 'ustr', 'c')
-            for i in range(157)
-        ]
+        entries = [DSStoreEntry(f"f{i:03d}", b"cmmt", "ustr", "c") for i in range(157)]
 
         # The 158th entry is alphabetically LARGEST (f999 > f156)
-        largest_entry = DSStoreEntry('f999', b'cmmt', 'ustr', 'c')
+        largest_entry = DSStoreEntry("f999", b"cmmt", "ustr", "c")
 
         with DSStore.open(str(ds_path), "w+") as ds:
             for e in entries:
@@ -53,7 +49,7 @@ class TestSplitWithLargestEntry:
 
         # Verify all entries exist
         with DSStore.open(str(ds_path), "r") as ds:
-            assert len(list(ds.find('f999'))) == 1
+            assert len(list(ds.find("f999"))) == 1
             assert len(list(ds)) == 158
 
     def test_insert_largest_with_different_fill_level(self, tmp_path):
@@ -61,16 +57,16 @@ class TestSplitWithLargestEntry:
         ds_path = tmp_path / ".DS_Store"
 
         # Use larger entries to reach the threshold faster
-        larger_entry_size = entry_size('file0000', 'comment_data')
+        larger_entry_size = entry_size("file0000", "comment_data")
         max_entries = AVAILABLE // larger_entry_size
 
         entries = [
-            DSStoreEntry(f'file{i:04d}', b'cmmt', 'ustr', 'comment_data')
+            DSStoreEntry(f"file{i:04d}", b"cmmt", "ustr", "comment_data")
             for i in range(max_entries)
         ]
 
         # Insert the largest entry
-        largest_entry = DSStoreEntry('file9999', b'cmmt', 'ustr', 'comment_data')
+        largest_entry = DSStoreEntry("file9999", b"cmmt", "ustr", "comment_data")
 
         with DSStore.open(str(ds_path), "w+") as ds:
             for e in entries:
@@ -79,19 +75,16 @@ class TestSplitWithLargestEntry:
 
         # Verify the largest entry exists
         with DSStore.open(str(ds_path), "r") as ds:
-            assert len(list(ds.find('file9999'))) == 1
+            assert len(list(ds.find("file9999"))) == 1
 
     def test_insert_middle_entry_succeeds(self, tmp_path):
         """Inserting a middle entry should succeed."""
         ds_path = tmp_path / ".DS_Store"
 
-        entries = [
-            DSStoreEntry(f'f{i:03d}', b'cmmt', 'ustr', 'c')
-            for i in range(157)
-        ]
+        entries = [DSStoreEntry(f"f{i:03d}", b"cmmt", "ustr", "c") for i in range(157)]
 
         # Insert an entry in the MIDDLE alphabetically (f050 < f050a < f051)
-        middle_entry = DSStoreEntry('f050a', b'cmmt', 'ustr', 'c')
+        middle_entry = DSStoreEntry("f050a", b"cmmt", "ustr", "c")
 
         with DSStore.open(str(ds_path), "w+") as ds:
             for e in entries:
@@ -100,19 +93,16 @@ class TestSplitWithLargestEntry:
 
         # Verify exactly one entry exists (not duplicates)
         with DSStore.open(str(ds_path), "r") as ds:
-            assert len(list(ds.find('f050a'))) == 1
+            assert len(list(ds.find("f050a"))) == 1
 
     def test_insert_smallest_entry_succeeds(self, tmp_path):
         """Inserting the smallest entry should succeed."""
         ds_path = tmp_path / ".DS_Store"
 
-        entries = [
-            DSStoreEntry(f'f{i:03d}', b'cmmt', 'ustr', 'c')
-            for i in range(157)
-        ]
+        entries = [DSStoreEntry(f"f{i:03d}", b"cmmt", "ustr", "c") for i in range(157)]
 
         # Insert the smallest entry alphabetically (a000 < f000)
-        smallest_entry = DSStoreEntry('a000', b'cmmt', 'ustr', 'c')
+        smallest_entry = DSStoreEntry("a000", b"cmmt", "ustr", "c")
 
         with DSStore.open(str(ds_path), "w+") as ds:
             for e in entries:
@@ -121,7 +111,7 @@ class TestSplitWithLargestEntry:
 
         # Verify exactly one entry exists
         with DSStore.open(str(ds_path), "r") as ds:
-            assert len(list(ds.find('a000'))) == 1
+            assert len(list(ds.find("a000"))) == 1
 
 
 class TestSequentialInsertion:
@@ -138,9 +128,7 @@ class TestSequentialInsertion:
 
         with DSStore.open(str(ds_path), "w+") as ds:
             for i in range(150):
-                entry = DSStoreEntry(
-                    f"file_{i:03d}", b"cmmt", "ustr", f"Comment {i}"
-                )
+                entry = DSStoreEntry(f"file_{i:03d}", b"cmmt", "ustr", f"Comment {i}")
                 ds.insert(entry)
 
         # Verify all entries exist
@@ -171,16 +159,14 @@ class TestInternalNodeSplit:
 
         def make_entry(prefix, num):
             name = f"{prefix}{num:04d}" + base[5:]
-            return DSStoreEntry(name, b'cmmt', 'ustr', 'x')
+            return DSStoreEntry(name, b"cmmt", "ustr", "x")
 
         # Build initial tree with 'm' prefix entries using initial_entries
         # (bypasses split bug during tree construction)
         entries_per_node = 18
         initial_count = entries_per_node * entries_per_node  # ~324 entries
 
-        initial_entries = sorted([
-            make_entry('m', i) for i in range(initial_count)
-        ])
+        initial_entries = sorted([make_entry("m", i) for i in range(initial_count)])
 
         # Create multi-level tree
         with DSStore.open(str(ds_path), "w+", initial_entries=initial_entries) as ds:
@@ -190,12 +176,12 @@ class TestInternalNodeSplit:
             # Insert 'a' entries in descending order (avoids leaf bug)
             # This grows the tree and fills internal nodes
             for i in range(entries_per_node * 5, -1, -1):
-                ds.insert(make_entry('a', i))
+                ds.insert(make_entry("a", i))
 
             # Insert 'z' entries in descending order
             # Eventually triggers internal node split with largest pivot
             for i in range(entries_per_node * 5, -1, -1):
-                ds.insert(make_entry('z', i))
+                ds.insert(make_entry("z", i))
 
         # Verify all entries exist
         with DSStore.open(str(ds_path), "r") as ds:
@@ -213,16 +199,16 @@ class TestSplitConsistency:
 
         # Use very long filenames to fill the page with fewer entries
         base_name = "a" * 100  # 100 character filename
-        single_entry_size = entry_size(base_name, 'x')
+        single_entry_size = entry_size(base_name, "x")
         max_entries = AVAILABLE // single_entry_size
 
         entries = [
-            DSStoreEntry(f'{chr(ord("a") + i)}' + base_name[1:], b'cmmt', 'ustr', 'x')
+            DSStoreEntry(f"{chr(ord('a') + i)}" + base_name[1:], b"cmmt", "ustr", "x")
             for i in range(max_entries)
         ]
 
         # The largest entry uses 'z' prefix
-        largest_entry = DSStoreEntry('z' + base_name[1:], b'cmmt', 'ustr', 'x')
+        largest_entry = DSStoreEntry("z" + base_name[1:], b"cmmt", "ustr", "x")
 
         with DSStore.open(str(ds_path), "w+") as ds:
             for e in entries:
@@ -231,7 +217,7 @@ class TestSplitConsistency:
 
         # Verify the entry was inserted
         with DSStore.open(str(ds_path), "r") as ds:
-            found = list(ds.find('z' + base_name[1:]))
+            found = list(ds.find("z" + base_name[1:]))
             assert len(found) == 1
 
     def test_100_sequential_insertions(self, tmp_path):
@@ -240,10 +226,9 @@ class TestSplitConsistency:
             ds_path = tmp_path / f".DS_Store_{run}"
 
             entries = [
-                DSStoreEntry(f'f{i:03d}', b'cmmt', 'ustr', 'c')
-                for i in range(157)
+                DSStoreEntry(f"f{i:03d}", b"cmmt", "ustr", "c") for i in range(157)
             ]
-            largest_entry = DSStoreEntry('f999', b'cmmt', 'ustr', 'c')
+            largest_entry = DSStoreEntry("f999", b"cmmt", "ustr", "c")
 
             with DSStore.open(str(ds_path), "w+") as ds:
                 for e in entries:
@@ -252,4 +237,4 @@ class TestSplitConsistency:
 
             # Verify
             with DSStore.open(str(ds_path), "r") as ds:
-                assert len(list(ds.find('f999'))) == 1
+                assert len(list(ds.find("f999"))) == 1

--- a/tests/test_split_bug.py
+++ b/tests/test_split_bug.py
@@ -1,0 +1,255 @@
+"""Tests for B-tree split behavior in DSStore.insert().
+
+These tests verify correct behavior when inserting entries that trigger
+a B-tree node split. Currently, there is a bug where inserting an entry
+that is alphabetically larger than all existing entries causes an IndexError.
+
+These tests FAIL with the current implementation and will PASS once fixed.
+"""
+
+from ds_store import DSStore, DSStoreEntry
+
+
+# Constants from the DS_Store implementation
+PAGE_SIZE = 4096
+HEADER_SIZE = 8  # next_node (4 bytes) + count (4 bytes)
+AVAILABLE = PAGE_SIZE - HEADER_SIZE  # 4088 bytes
+
+
+def entry_size(filename, value='x'):
+    """Calculate the byte size of an entry."""
+    entry = DSStoreEntry(filename, b'cmmt', 'ustr', value)
+    return entry.byte_length()
+
+
+class TestSplitWithLargestEntry:
+    """Tests for inserting the alphabetically largest entry during a split."""
+
+    def test_insert_largest_entry_succeeds(self, tmp_path):
+        """Inserting the alphabetically largest entry should succeed.
+
+        Setup:
+        - Fill a leaf node with entries that use most of the available space
+        - Insert an entry that is alphabetically LARGER than all existing entries
+        - The split should handle this correctly and insert the entry
+        """
+        ds_path = tmp_path / ".DS_Store"
+
+        # Each entry 'fNNN'/'c' is 26 bytes
+        # 157 entries = 4082 bytes, leaving 6 bytes remaining
+        # Any new entry (min 24 bytes) will trigger a split
+        entries = [
+            DSStoreEntry(f'f{i:03d}', b'cmmt', 'ustr', 'c')
+            for i in range(157)
+        ]
+
+        # The 158th entry is alphabetically LARGEST (f999 > f156)
+        largest_entry = DSStoreEntry('f999', b'cmmt', 'ustr', 'c')
+
+        with DSStore.open(str(ds_path), "w+") as ds:
+            for e in entries:
+                ds.insert(e)
+            ds.insert(largest_entry)  # Should succeed, not raise
+
+        # Verify all entries exist
+        with DSStore.open(str(ds_path), "r") as ds:
+            assert len(list(ds.find('f999'))) == 1
+            assert len(list(ds)) == 158
+
+    def test_insert_largest_with_different_fill_level(self, tmp_path):
+        """Split should work regardless of how full the page is."""
+        ds_path = tmp_path / ".DS_Store"
+
+        # Use larger entries to reach the threshold faster
+        larger_entry_size = entry_size('file0000', 'comment_data')
+        max_entries = AVAILABLE // larger_entry_size
+
+        entries = [
+            DSStoreEntry(f'file{i:04d}', b'cmmt', 'ustr', 'comment_data')
+            for i in range(max_entries)
+        ]
+
+        # Insert the largest entry
+        largest_entry = DSStoreEntry('file9999', b'cmmt', 'ustr', 'comment_data')
+
+        with DSStore.open(str(ds_path), "w+") as ds:
+            for e in entries:
+                ds.insert(e)
+            ds.insert(largest_entry)  # Should succeed
+
+        # Verify the largest entry exists
+        with DSStore.open(str(ds_path), "r") as ds:
+            assert len(list(ds.find('file9999'))) == 1
+
+    def test_insert_middle_entry_succeeds(self, tmp_path):
+        """Inserting a middle entry should succeed."""
+        ds_path = tmp_path / ".DS_Store"
+
+        entries = [
+            DSStoreEntry(f'f{i:03d}', b'cmmt', 'ustr', 'c')
+            for i in range(157)
+        ]
+
+        # Insert an entry in the MIDDLE alphabetically (f050 < f050a < f051)
+        middle_entry = DSStoreEntry('f050a', b'cmmt', 'ustr', 'c')
+
+        with DSStore.open(str(ds_path), "w+") as ds:
+            for e in entries:
+                ds.insert(e)
+            ds.insert(middle_entry)
+
+        # Verify exactly one entry exists (not duplicates)
+        with DSStore.open(str(ds_path), "r") as ds:
+            assert len(list(ds.find('f050a'))) == 1
+
+    def test_insert_smallest_entry_succeeds(self, tmp_path):
+        """Inserting the smallest entry should succeed."""
+        ds_path = tmp_path / ".DS_Store"
+
+        entries = [
+            DSStoreEntry(f'f{i:03d}', b'cmmt', 'ustr', 'c')
+            for i in range(157)
+        ]
+
+        # Insert the smallest entry alphabetically (a000 < f000)
+        smallest_entry = DSStoreEntry('a000', b'cmmt', 'ustr', 'c')
+
+        with DSStore.open(str(ds_path), "w+") as ds:
+            for e in entries:
+                ds.insert(e)
+            ds.insert(smallest_entry)
+
+        # Verify exactly one entry exists
+        with DSStore.open(str(ds_path), "r") as ds:
+            assert len(list(ds.find('a000'))) == 1
+
+
+class TestSequentialInsertion:
+    """Test sequential insertion that naturally triggers splits."""
+
+    def test_sequential_insertion_succeeds(self, tmp_path):
+        """Sequential insertion of alphabetically ordered entries should work.
+
+        When inserting entries in alphabetical order (file_000, file_001, ...),
+        each new entry is larger than all existing entries. Once the node
+        fills up, the split should handle this correctly.
+        """
+        ds_path = tmp_path / ".DS_Store"
+
+        with DSStore.open(str(ds_path), "w+") as ds:
+            for i in range(150):
+                entry = DSStoreEntry(
+                    f"file_{i:03d}", b"cmmt", "ustr", f"Comment {i}"
+                )
+                ds.insert(entry)
+
+        # Verify all entries exist
+        with DSStore.open(str(ds_path), "r") as ds:
+            all_entries = list(ds)
+            assert len(all_entries) == 150
+
+
+class TestInternalNodeSplit:
+    """Tests for the bug in _insert_inner() when splitting internal nodes."""
+
+    def test_internal_node_split_with_largest_pivot(self, tmp_path):
+        """Internal node split should handle largest pivot correctly.
+
+        This test triggers the same bug but in _insert_inner() instead of
+        _insert_leaf(). The bug occurs when:
+        1. A leaf split produces a pivot
+        2. That pivot must be inserted into a nearly-full internal node
+        3. The internal node splits, but the pivot is largest in that node
+
+        Stack trace when bug triggers:
+        _insert_leaf() -> _insert_inner() -> _split() -> IndexError
+        """
+        ds_path = tmp_path / ".DS_Store"
+
+        # Use large entries to reduce entries per node
+        base = "x" * 100  # 218 bytes per entry, ~18 per node
+
+        def make_entry(prefix, num):
+            name = f"{prefix}{num:04d}" + base[5:]
+            return DSStoreEntry(name, b'cmmt', 'ustr', 'x')
+
+        # Build initial tree with 'm' prefix entries using initial_entries
+        # (bypasses split bug during tree construction)
+        entries_per_node = 18
+        initial_count = entries_per_node * entries_per_node  # ~324 entries
+
+        initial_entries = sorted([
+            make_entry('m', i) for i in range(initial_count)
+        ])
+
+        # Create multi-level tree
+        with DSStore.open(str(ds_path), "w+", initial_entries=initial_entries) as ds:
+            assert ds._levels >= 2  # Must have internal nodes
+
+        with DSStore.open(str(ds_path), "r+") as ds:
+            # Insert 'a' entries in descending order (avoids leaf bug)
+            # This grows the tree and fills internal nodes
+            for i in range(entries_per_node * 5, -1, -1):
+                ds.insert(make_entry('a', i))
+
+            # Insert 'z' entries in descending order
+            # Eventually triggers internal node split with largest pivot
+            for i in range(entries_per_node * 5, -1, -1):
+                ds.insert(make_entry('z', i))
+
+        # Verify all entries exist
+        with DSStore.open(str(ds_path), "r") as ds:
+            all_entries = list(ds)
+            expected = initial_count + (entries_per_node * 5 + 1) * 2
+            assert len(all_entries) == expected
+
+
+class TestSplitConsistency:
+    """Tests verifying split behavior is consistent."""
+
+    def test_minimal_largest_entry_case(self, tmp_path):
+        """Minimal test case for largest entry insertion."""
+        ds_path = tmp_path / ".DS_Store"
+
+        # Use very long filenames to fill the page with fewer entries
+        base_name = "a" * 100  # 100 character filename
+        single_entry_size = entry_size(base_name, 'x')
+        max_entries = AVAILABLE // single_entry_size
+
+        entries = [
+            DSStoreEntry(f'{chr(ord("a") + i)}' + base_name[1:], b'cmmt', 'ustr', 'x')
+            for i in range(max_entries)
+        ]
+
+        # The largest entry uses 'z' prefix
+        largest_entry = DSStoreEntry('z' + base_name[1:], b'cmmt', 'ustr', 'x')
+
+        with DSStore.open(str(ds_path), "w+") as ds:
+            for e in entries:
+                ds.insert(e)
+            ds.insert(largest_entry)  # Should succeed
+
+        # Verify the entry was inserted
+        with DSStore.open(str(ds_path), "r") as ds:
+            found = list(ds.find('z' + base_name[1:]))
+            assert len(found) == 1
+
+    def test_100_sequential_insertions(self, tmp_path):
+        """Verify sequential insertions work consistently across 100 files."""
+        for run in range(100):
+            ds_path = tmp_path / f".DS_Store_{run}"
+
+            entries = [
+                DSStoreEntry(f'f{i:03d}', b'cmmt', 'ustr', 'c')
+                for i in range(157)
+            ]
+            largest_entry = DSStoreEntry('f999', b'cmmt', 'ustr', 'c')
+
+            with DSStore.open(str(ds_path), "w+") as ds:
+                for e in entries:
+                    ds.insert(e)
+                ds.insert(largest_entry)
+
+            # Verify
+            with DSStore.open(str(ds_path), "r") as ds:
+                assert len(list(ds.find('f999'))) == 1


### PR DESCRIPTION
# Bug: Duplicate entries and IndexError during B-tree node split

I was working on a project that was using this library and was running into this occasional `IndexError`. I iterated on it for a while with Claude Code and came up with a root cause and a repro. This PR includes tests that demonstrate the issue as well as the proposed fix. Hopefully the report here and the fix are correct, I've tried to verify it to the best of my ability.

## Summary

`DSStore.insert()` has a bug in the `_split()` method that manifests in two ways depending on where the new entry belongs alphabetically:

1. **Duplicate entries**: When inserting an entry in the middle of existing entries, it gets added multiple times
2. **IndexError**: When inserting an entry larger than all existing entries, it never gets added, causing a crash

Both symptoms have the same root cause.

## Root Cause

In `_split()`, the loop that builds the new entry list checks `if e > entry:` for every existing entry:

```python
for n in range(count):
    ...
    e = DSStoreEntry.read(block)
    if e > entry:
        entries.append(entry)   # BUG: No tracking of whether already added
        ...
    entries.append(e)
```

**Problem 1 (duplicates):** When inserting `f050a` into `[f000, ..., f156]`:
- `f051 > f050a`? Yes → add f050a, add f051
- `f052 > f050a`? Yes → add f050a AGAIN, add f052
- ... (repeats for every remaining entry)

**Problem 2 (IndexError):** When inserting `f999` into `[f000, ..., f156]`:
- No entry is greater than f999
- `if e > entry:` is never true
- f999 is never added to the list
- `_split2()` receives only old entries, fits in one node, returns `[]`
- Caller crashes: `pivot = self._split2(...)[0]` → IndexError

## Minimal Reproduction

```python
from ds_store import DSStore, DSStoreEntry

# Duplicates case (middle entry)
with DSStore.open(".DS_Store", "w+") as ds:
    for i in range(157):
        ds.insert(DSStoreEntry(f'f{i:03d}', b'cmmt', 'ustr', 'c'))
    ds.insert(DSStoreEntry('f050a', b'cmmt', 'ustr', 'c'))  # Triggers split

with DSStore.open(".DS_Store", "r") as ds:
    print(f"Total: {len(list(ds))}")  # Expected: 158, Actual: 263
    print(f"f050a copies: {len(list(ds.find('f050a')))}")  # Expected: 1, Actual: 41+

# IndexError case (largest entry)
with DSStore.open(".DS_Store2", "w+") as ds:
    for i in range(157):
        ds.insert(DSStoreEntry(f'f{i:03d}', b'cmmt', 'ustr', 'c'))
    ds.insert(DSStoreEntry('f999', b'cmmt', 'ustr', 'c'))  # IndexError!
```

## Trigger Conditions

1. A B-tree node is nearly full (approaching 4088 bytes)
2. An insert triggers a node split
3. The bug manifests differently based on entry position:
   - Middle/smallest entry → duplicates
   - Largest entry → IndexError

## Suggested Fix

Add a flag to track whether the entry has been inserted:

```python
inserted = False
for n in range(count):
    ...
    e = DSStoreEntry.read(block)
    if not inserted and e > entry:
        inserted = True
        entries.append(entry)
        ...
    entries.append(e)
    ...
# Handle largest entry case
if not inserted:
    entries.append(entry)
    ...
```

This ensures the entry is added exactly once in the correct sorted position.

## Affected Code

- `src/ds_store/store.py`: `_split()` method (lines ~543-593)
- Both `_insert_leaf()` and `_insert_inner()` call `_split()`, so both leaf and internal node splits are affected
