### PR TITLE
Decode binary-plist blob values in CLI output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,3 +132,5 @@ extend-select = [
 [tool.ruff.lint.per-file-ignores]
 # E501: line too long
 "tests/examples/settings.py" = ["E501"]
+# T201: the command-line tool legitimately writes its output to stdout
+"src/ds_store/__main__.py" = ["T201"]

--- a/src/ds_store/__main__.py
+++ b/src/ds_store/__main__.py
@@ -6,6 +6,7 @@
 import argparse
 import os
 import os.path
+import plistlib
 import pprint
 import re
 import sys
@@ -26,6 +27,14 @@ def chunks(iterable, length):
 
 
 def pretty(value):
+    if isinstance(value, (bytes, bytearray)) and bytes(value[:8]) == b"bplist00":
+        # Several records (e.g. lsvC) store a binary plist; show the decoded
+        # contents rather than a raw hex dump or latin-1 bytes.
+        try:
+            return pretty(plistlib.loads(bytes(value)))
+        except Exception:
+            pass
+
     if isinstance(value, dict):
         return f"{{\n {pprint.pformat(value, indent=4)[1:-1]}\n}}"
     elif isinstance(value, bytearray):

--- a/src/ds_store/__main__.py
+++ b/src/ds_store/__main__.py
@@ -43,7 +43,7 @@ def pretty(value):
         return value
 
 
-def main(argv):
+def main(argv=None):
     """Display the contents of the .DS_Store file at the specified path.
 
     If you specify just a directory, ds_store will inspect the .DS_Store
@@ -64,11 +64,15 @@ def main(argv):
             path = os.path.join(path, ".DS_Store")
 
         if not os.path.exists(path) or not os.path.isfile(path):
+            print(f"ds_store: {path} not found", file=sys.stderr)
             failed = True
             continue
 
         try:
             with DSStore.open(path, "r") as d:
+                print(path)
+                print()
+
                 max_name_len = 0
                 for entry in d:
                     name_len = len(entry.filename)
@@ -76,8 +80,17 @@ def main(argv):
                         max_name_len = name_len
 
                 for entry in d:
-                    pass
-        except BuddyError:
+                    print(
+                        "{:<{width}} {} {}".format(
+                            entry.filename,
+                            entry.code.decode("latin-1"),
+                            pretty(entry.value),
+                            width=max_name_len,
+                        )
+                    )
+                print()
+        except BuddyError as e:
+            print(f"ds_store: {path}: {e}")
             failed = True
 
     if failed:

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,7 +1,8 @@
 # Some basic test code
 import os
+import sys
 
-from ds_store import DSStore
+from ds_store import DSStore, __main__
 
 
 def test_create(tmpdir):
@@ -47,3 +48,24 @@ def test_find(tmpdir):
         assert len(bamIloc) == 1
         bam = list(store.find("bam"))
         assert bamIloc == bam
+
+
+def test_cli_prints_entries(capsys):
+    """The command-line tool should print the entries it reads, not swallow
+    them. Guards against the loop being reduced to ``pass``."""
+    __main__.main(["tests/Test_DS_Store"])
+
+    out = capsys.readouterr().out
+    assert "bam" in out
+    assert "Iloc" in out
+
+
+def test_cli_entry_point_takes_no_args(capsys, monkeypatch):
+    """The console_scripts entry point calls ``main()`` with no arguments, so
+    ``argv`` must default to ``sys.argv[1:]``. Guards against a TypeError on
+    every invocation."""
+    monkeypatch.setattr(sys, "argv", ["ds_store", "tests/Test_DS_Store"])
+
+    __main__.main()  # must not raise
+
+    assert "bam" in capsys.readouterr().out

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,5 +1,6 @@
 # Some basic test code
 import os
+import plistlib
 import sys
 
 from ds_store import DSStore, __main__
@@ -69,3 +70,16 @@ def test_cli_entry_point_takes_no_args(capsys, monkeypatch):
     __main__.main()  # must not raise
 
     assert "bam" in capsys.readouterr().out
+
+
+def test_pretty_decodes_binary_plist():
+    """Binary-plist blob values (e.g. lsvC) render as their decoded contents,
+    not as a raw hex dump or latin-1 bytes."""
+    blob = plistlib.dumps({"sortColumn": "dateAdded"}, fmt=plistlib.FMT_BINARY)
+
+    # blob records arrive as bytearray, plain plists as bytes; handle both.
+    for value in (blob, bytearray(blob)):
+        out = __main__.pretty(value)
+        assert "sortColumn" in out
+        assert "dateAdded" in out
+        assert "bplist00" not in out


### PR DESCRIPTION
Fixes #219.

Several `.DS_Store` records (e.g. `lsvC`) store their value as a binary
plist. `pretty()` rendered those as a raw hex dump (for `bytearray`) or
latin-1 bytes (for `bytes`), so they are effectively unreadable in the CLI output.

This detects the `bplist00` signature and renders the decoded contents
instead, falling back to the existing rendering if the bytes are not a valid
plist.

### Changes
- `src/ds_store/__main__.py` — decode `bplist00` blob values in `pretty()`
- `tests/test_basics.py` — test that `bytes` and `bytearray` binary-plist
  values are decoded rather than hex-dumped

### Important
Builds on #218 — that PR restores the CLI's output, without which `pretty()`
is never called. **#218 should be merged first.** This branch is stacked on
it (so until #218 lands this PR's diff also shows the #218 commit); once it
merges I'll rebase onto `main` to leave just the blob-decoding change.
