### PR TITLE
Use workflow-specific URLs for the CI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,8 @@ ds_store
    :target: https://github.com/dmgbuild/ds_store/blob/main/LICENSE
    :alt: MIT License
 
-.. |ci| image:: https://github.com/dmgbuild/ds_store/workflows/CI/badge.svg?branch=main
-   :target: https://github.com/dmgbuild/ds_store/actions
+.. |ci| image:: https://github.com/dmgbuild/ds_store/actions/workflows/ci.yml/badge.svg?branch=main
+   :target: https://github.com/dmgbuild/ds_store/actions/workflows/ci.yml
    :alt: Build Status
 
 |pyversions| |version| |maturity| |license| |ci|


### PR DESCRIPTION
The CI badge showed "no status" because it used the legacy `workflows/CI/badge.svg` image URL and linked to the Actions page. Point both the image and the target at the `ci.yml` workflow (`actions/workflows/ci.yml`), so the badge resolves correctly.