### PR TITLE
Upgrade from Mac OS X to macOS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ What is this?
 
 ``ds_store`` lets you examine and modify ``.DS_Store`` files from Python
 code; since it is written in pure Python, it is portable and will run on any
-platform, not just Mac OS X.
+platform, not just macOS.
 
 Credit is due to Wim Lewis, Mark Mentovai and Yvan Barthélemy for
 reverse-engineering the .DS_Store file format. See

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,13 +11,13 @@ This document refers to version |release|
 What is this?
 =============
 
-Historically the Mac OS Finder stored additional per-file information in a
+Historically the macOS Finder stored additional per-file information in a
 special Finder Info field in the HFS/HFS+ filesystem.  It also held other
 information in a single file known as the Desktop Database.
 
 Filesystems other than HFS obviously do not have the Finder Info structure,
 and until recently support for extended attributes was rare.  As a result, the
-Mac OS X Finder was written to store the necessary information in hidden files
+macOS Finder was written to store the necessary information in hidden files
 named ``.DS_Store``, which it places into every directory where it needs to
 store information.
 
@@ -30,12 +30,12 @@ to set many of these things is via Finder itself.  You might think that you
 could drive Finder with AppleScript for this purpose, but this turns out to be
 unreliable (Finder may not save the changes to the ``.DS_Store`` file
 immediately), and worse still Apple has made changes to the information Finder
-uses between versions of Mac OS X, such that setting some of these things on
-newer versions of the OS X Finder will not set them for users of older
+uses between versions of macOS, such that setting some of these things on
+newer versions of the macOS Finder will not set them for users of older
 versions.
 
 This module allows programmatic access to and construction of ``.DS_Store``
-files directly from Python, with no Mac OS X specific code involved.
+files directly from Python, with no macOS specific code involved.
 
 Usage
 =====

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -19,7 +19,7 @@ def test_create(tmpdir):
 
 
 def test_can_read(tmpdir):
-    """Test that we can retrieve data from a .DS_Store file written by OS X."""
+    """Test that we can retrieve data from a .DS_Store file written by macOS."""
     with DSStore.open("tests/Test_DS_Store", "r") as store:
         assert store["bam"]["Iloc"] == (104, 116)
         assert store["bar"]["Iloc"] == (256, 235)


### PR DESCRIPTION
 The operating system has been named [__macOS__](https://www.apple.com/os/macos) since 2019.
* https://en.wikipedia.org/wiki/MacOS
* https://en.wikipedia.org/wiki/MacOS_version_history
* https://en.wikipedia.org/wiki/MacOS_Sierra